### PR TITLE
Temporarily disable setting preemptibility

### DIFF
--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -946,5 +946,11 @@ class DataprocSpawner(Spawner):
     if (cluster_data['config'].setdefault('secondary_worker_config', {})):
       cluster_data['config']['secondary_worker_config'].pop('preemptibility', None)
 
+    # Strip cluster-specific namenode properties
+    if (cluster_data['config'].setdefault('software_config', {}) and
+        cluster_data['config']['software_config'].setdefault('properties', {})):
+        cluster_data['config']['software_config']['properties'].pop('hdfs:dfs.namenode.lifeline.rpc-address', None)
+        cluster_data['config']['software_config']['properties'].pop('hdfs:dfs.namenode.servicerpc-address', None)
+
     self.log.info(f'Cluster configuration data is {cluster_data}')
     return cluster_data

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -936,6 +936,15 @@ class DataprocSpawner(Spawner):
         .setdefault('endpoint_config', {})
         .setdefault('enable_http_port_access', False)):
       cluster_data['config']['endpoint_config']['enable_http_port_access'] = False
+    
+    # Temporarily disable setting preemptibility field until Dataproc client
+    # libraries support the enum value
+    if (cluster_data['config'].setdefault('master_config', {})):
+      cluster_data['config']['master_config'].pop('preemptibility', None)
+    if (cluster_data['config'].setdefault('worker_config', {})):
+      cluster_data['config']['worker_config'].pop('preemptibility', None)
+    if (cluster_data['config'].setdefault('secondary_worker_config', {})):
+      cluster_data['config']['secondary_worker_config'].pop('preemptibility', None)
 
     self.log.info(f'Cluster configuration data is {cluster_data}')
     return cluster_data

--- a/tests/test_data/export.yaml
+++ b/tests/test_data/export.yaml
@@ -1,0 +1,117 @@
+clusterName: 'overwrite'
+config:
+  configBucket: dataproc-staging-us-east1-935823299908-gvss3h0b
+  endpointConfig:
+    enableHttpPortAccess: true
+  gceClusterConfig:
+    metadata:
+      VmDnsSetting: ZonalPreferred
+      alluxio_download_path: https://downloads.alluxio.io/protected/files/alluxio-enterprise-trial.tar.gz
+      alluxio_hive_catalog_host: on-prem-a-m.us-west1-a.c.alluxio-demo.internal
+      alluxio_root_ufs_uri: hdfs://on-prem-a-m.us-west1-a.c.alluxio-demo.internal:8020
+      alluxio_site_properties: alluxio.user.file.passive.cache.enabled=false;alluxio.user.ufs.block.read.location.policy=alluxio.client.block.policy.DeterministicHashPolicy;alluxio.user.ufs.block.read.location.policy.deterministic.hash.shards=3;alluxio.master.mount.table.root.option.alluxio.underfs.hdfs.remote=true
+      alluxio_ssd_capacity_usage: '60'
+      alluxio_sync_list: /tmp
+    serviceAccountScopes:
+    - https://www.googleapis.com/auth/bigquery
+    - https://www.googleapis.com/auth/bigtable.admin.table
+    - https://www.googleapis.com/auth/bigtable.data
+    - https://www.googleapis.com/auth/cloud.useraccounts.readonly
+    - https://www.googleapis.com/auth/devstorage.full_control
+    - https://www.googleapis.com/auth/devstorage.read_write
+    - https://www.googleapis.com/auth/logging.write
+    subnetworkUri: https://www.googleapis.com/compute/v1/projects/alluxio-demo/regions/us-east1/subnetworks/subnet1-b
+    zoneUri: https://www.googleapis.com/compute/v1/projects/alluxio-demo/zones/us-east1-d
+  initializationActions:
+  - executableFile: gs://alluxio-public/gcp-burst-tutorial/stable/alluxio-dataproc.sh
+    executionTimeout: 600s
+  - executableFile: gs://alluxio-public/gcp-burst-tutorial/stable/alluxio-presto-conf.sh
+    executionTimeout: 
+      seconds: 600
+      nanos: 0
+  masterConfig:
+    diskConfig:
+      bootDiskSizeGb: 1000
+      bootDiskType: pd-standard
+    imageUri: https://www.googleapis.com/compute/v1/projects/cloud-dataproc/global/images/dataproc-1-4-deb10-20200409-000000-rc01
+    machineTypeUri: https://www.googleapis.com/compute/v1/projects/alluxio-demo/zones/us-east1-d/machineTypes/n1-highmem-16
+    minCpuPlatform: AUTOMATIC
+    numInstances: 1
+    preemptibility: NON_PREEMPTIBLE
+  softwareConfig:
+    imageVersion: 1.4.27-debian10
+    optionalComponents:
+    - JUPYTER
+    - ZEPPELIN
+    - ANACONDA
+    - PRESTO
+    properties:
+      capacity-scheduler:yarn.scheduler.capacity.root.default.ordering-policy: fair
+      core:fs.gs.block.size: '134217728'
+      core:fs.gs.metadata.cache.enable: 'false'
+      core:hadoop.ssl.enabled.protocols: TLSv1,TLSv1.1,TLSv1.2
+      distcp:mapreduce.map.java.opts: -Xmx768m
+      distcp:mapreduce.map.memory.mb: '1024'
+      distcp:mapreduce.reduce.java.opts: -Xmx768m
+      distcp:mapreduce.reduce.memory.mb: '1024'
+      hdfs:dfs.datanode.address: 0.0.0.0:9866
+      hdfs:dfs.datanode.http.address: 0.0.0.0:9864
+      hdfs:dfs.datanode.https.address: 0.0.0.0:9865
+      hdfs:dfs.datanode.ipc.address: 0.0.0.0:9867
+      hdfs:dfs.namenode.datanode.registration.ip-hostname-check: 'false'
+      hdfs:dfs.namenode.handler.count: '60'
+      hdfs:dfs.namenode.http-address: 0.0.0.0:9870
+      hdfs:dfs.namenode.https-address: 0.0.0.0:9871
+      hdfs:dfs.namenode.lifeline.rpc-address: cloud-compute-b-m:8050
+      hdfs:dfs.namenode.secondary.http-address: 0.0.0.0:9868
+      hdfs:dfs.namenode.secondary.https-address: 0.0.0.0:9869
+      hdfs:dfs.namenode.service.handler.count: '30'
+      hdfs:dfs.namenode.servicerpc-address: cloud-compute-b-m:8051
+      mapred-env:HADOOP_JOB_HISTORYSERVER_HEAPSIZE: '4000'
+      mapred:mapreduce.job.maps: '237'
+      mapred:mapreduce.job.reduce.slowstart.completedmaps: '0.95'
+      mapred:mapreduce.job.reduces: '79'
+      mapred:mapreduce.map.cpu.vcores: '1'
+      mapred:mapreduce.map.java.opts: -Xmx4096m
+      mapred:mapreduce.map.memory.mb: '5120'
+      mapred:mapreduce.reduce.cpu.vcores: '1'
+      mapred:mapreduce.reduce.java.opts: -Xmx4096m
+      mapred:mapreduce.reduce.memory.mb: '5120'
+      mapred:mapreduce.task.io.sort.mb: '256'
+      mapred:yarn.app.mapreduce.am.command-opts: -Xmx4096m
+      mapred:yarn.app.mapreduce.am.resource.cpu-vcores: '1'
+      mapred:yarn.app.mapreduce.am.resource.mb: '5120'
+      presto-catalog:onprem.connector.name: hive-hadoop2
+      presto-catalog:onprem.hive.config.resources: /opt/alluxio/conf/presto/core-site.xml
+      presto-catalog:onprem.hive.force-local-scheduling: 'false'
+      presto-catalog:onprem.hive.metastore.uri: thrift://on-prem-a-m.us-west1-a.c.alluxio-demo.internal:9083
+      presto-jvm:MaxHeapSize: 85196m
+      presto:query.max-memory-per-node: 51117MB
+      presto:query.max-total-memory-per-node: 51117MB
+      spark-env:SPARK_DAEMON_MEMORY: 4000m
+      spark:spark.driver.maxResultSize: 13312m
+      spark:spark.driver.memory: 26624m
+      spark:spark.executor.cores: '8'
+      spark:spark.executor.instances: '2'
+      spark:spark.executor.memory: 37237m
+      spark:spark.executorEnv.OPENBLAS_NUM_THREADS: '1'
+      spark:spark.scheduler.mode: FAIR
+      spark:spark.sql.cbo.enabled: 'true'
+      spark:spark.yarn.am.memory: 640m
+      yarn-env:YARN_NODEMANAGER_HEAPSIZE: '4000'
+      yarn-env:YARN_RESOURCEMANAGER_HEAPSIZE: '4000'
+      yarn-env:YARN_TIMELINESERVER_HEAPSIZE: '4000'
+      yarn:yarn.nodemanager.resource.memory-mb: '81920'
+      yarn:yarn.resourcemanager.nodemanager-graceful-decommission-timeout-secs: '86400'
+      yarn:yarn.scheduler.maximum-allocation-mb: '81920'
+      yarn:yarn.scheduler.minimum-allocation-mb: '1024'
+  workerConfig:
+    diskConfig:
+      bootDiskSizeGb: 1000
+      bootDiskType: pd-standard
+      numLocalSsds: 2
+    imageUri: https://www.googleapis.com/compute/v1/projects/cloud-dataproc/global/images/dataproc-1-4-deb10-20200409-000000-rc01
+    machineTypeUri: https://www.googleapis.com/compute/v1/projects/alluxio-demo/zones/us-east1-d/machineTypes/n1-highmem-16
+    minCpuPlatform: AUTOMATIC
+    numInstances: 5
+    preemptibility: NON_PREEMPTIBLE

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -323,6 +323,13 @@ class TestDataprocSpawner:
     # assert config_built['config']['software_config']['properties']['dataproc:jupyter.notebook.gcs.dir'] == f'gs://users-notebooks/fake'
     assert config_built['config']['software_config']['properties']['dataproc:jupyter.hub.env'] == 'test-env-str'
 
+    # Verify that we disable Component Gateway (temporarily)
+    assert config_built['config']['endpoint_config']['enable_http_port_access'] == False
+    # Verify that we disable preemptibility (temporarily)
+    assert 'preemptibility' not in config_built['config']['master_config']
+    assert 'preemptibility' not in config_built['config']['worker_config']
+    assert 'preemptibility' not in config_built['config']['secondary_worker_config']
+
   def test_cluster_definition_does_form_overwrite(self, monkeypatch):
     """ Values chosen by the user through the form overwrites others. If the 
     admin wants to prevent that behavior, they should remove form elements. 


### PR DESCRIPTION
This is necessary until our generated Python client libraries are updated with the new field