### PR TITLE
Run unit tests on PRs and pushes

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,6 @@
 name: Python Unit Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Currently unit tests only run on push, which means that PRs from a forked repo don't have tests run against them by default.

This change fixes that.