### PR TITLE
Disk types and internal IPs are now supported in the UI

### DIFF
--- a/dataprocspawner/customize_cluster.py
+++ b/dataprocspawner/customize_cluster.py
@@ -108,6 +108,14 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
       html_master_type += f'''<option value="{t}">{t}</option>'''
     html_master_type += "</select></div>"
 
+  html_master_disk_type = ""
+  html_master_disk_type += """<div class="form-group">
+      <label for="master_disk_type">Master disk type</label>
+      <select class="form-control" name="master_disk_type">"""
+  html_master_disk_type += '''<option value="">pd-standard</option>
+      <option value="">pd-ssd</option>'''
+  html_master_disk_type += "</select></div>"
+
   html_master_disc = """<div class="form-group">
       <label for="master_node_disc_size">Master disk size</label>
       <input name="master_node_disc_size" class="form-control" placeholder="default"
@@ -123,6 +131,14 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
     for t in node_types:
       html_worker_type += f'''<option value="{t}">{t}</option>'''
     html_worker_type += "</select></div>"
+
+  html_worker_disk_type = ""
+  html_worker_disk_type += """<div class="form-group">
+      <label for="worker_disk_type">Worker disk type</label>
+      <select class="form-control" name="worker_disk_type">"""
+  html_worker_disk_type += '''<option value="">pd-standard</option>
+      <option value="">pd-ssd</option>'''
+  html_worker_disk_type += "</select></div>"
 
   html_worker_disc = """<div class="form-group">
       <label for="worker_node_disc_size">Worker disc size</label>
@@ -161,8 +177,10 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
       html_pip_packages,
       html_condo_packages,
       html_master_type,
+      html_master_disk_type,
       html_master_disc,
       html_worker_type,
+      html_worker_disk_type,
       html_worker_disc,
       html_worker_amount,
       html_custom_labels,

--- a/dataprocspawner/customize_cluster.py
+++ b/dataprocspawner/customize_cluster.py
@@ -98,6 +98,11 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
             value=""></input>
   </div>"""
 
+  html_internal_ip_only = """<div class="form-group">
+    <label for="internal_ip_only">Internal IP only</label>
+    <input name="internal_ip_only" type="checkbox"></input>
+  </div>"""
+
   html_master_type = ""
   if node_types:
     html_master_type += """<div class="form-group">
@@ -176,6 +181,7 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
       html_autoscaling_policy,
       html_pip_packages,
       html_condo_packages,
+      html_internal_ip_only,
       html_master_type,
       html_master_disk_type,
       html_master_disc,

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -1048,6 +1048,10 @@ class DataprocSpawner(Spawner):
           }
       )
 
+    if self.user_options.get('internal_ip_only'):
+      config.setdefault('master_config', {})
+      config['gce_cluster_config']['internal_ip_only'] = True
+
     if self.user_options.get('master_node_type'):
       config.setdefault('master_config', {})
       config['master_config']['machine_type_uri'] = self.user_options.get('master_node_type')

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -1056,6 +1056,14 @@ class DataprocSpawner(Spawner):
       config.setdefault('worker_config', {})
       config['worker_config']['machine_type_uri'] = self.user_options.get('worker_node_type')
 
+    if self.user_options.get('master_disk_type'):
+      config.setdefault('master_config', {})
+      config['master_config']['disk_config']['boot_disk_type'] = self.user_options.get('master_disk_type')
+
+    if self.user_options.get('worker_disk_type'):
+      config.setdefault('worker_config', {})
+      config['worker_config']['disk_config']['boot_disk_type'] = self.user_options.get('worker_disk_type')
+
     if self.user_options.get('master_node_disc_size'):
       try:
         val = int(self.user_options.get('master_node_disc_size'))


### PR DESCRIPTION
Choose either standard or ssd for your master/worker nodes.
Configure all instances to have only internal IP addresses.