### PR TITLE
Add proxy to local file. Remove blocking gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@ overwrite.sh
 tries/
 .prettierrc.js
 deploy_ain_example.sh
-/Dockerfile
-/jupyterhub_config.py

--- a/deploy_gce_example.sh
+++ b/deploy_gce_example.sh
@@ -27,7 +27,7 @@
 PROJECT_ID=$1
 VM_NAME=$2
 CONFIGS_LOCATION=$3
-DOCKER_IMAGE="gcr.io/${PROJECT_ID}/dataprocspawner:cg"
+DOCKER_IMAGE="gcr.io/${PROJECT_ID}/dataprocspawner:gce"
 
 cat <<EOT > Dockerfile
 FROM jupyterhub/jupyterhub

--- a/deploy_local_example.sh
+++ b/deploy_local_example.sh
@@ -29,13 +29,10 @@ RUN apt-get update \
   && apt-get remove -y vim
 
 COPY jupyterhub_config.py .
-
 COPY . dataprocspawner/
 RUN cd dataprocspawner && pip install .
 
 COPY dataprochub dataprochub
-
-COPY templates /etc/jupyterhub/templates
 
 ENTRYPOINT ["jupyterhub"]
 EOT
@@ -55,6 +52,7 @@ cat <<EOT > jupyterhub_config.py
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+c.JupyterHub.proxy_class = 'redirect-proxy'
 c.JupyterHub.authenticator_class = 'dummyauthenticator.DummyAuthenticator'
 c.JupyterHub.spawner_class = 'dataprocspawner.DataprocSpawner'
 # The port that the spawned notebook listens on for the hub to connect
@@ -72,27 +70,6 @@ c.DataprocSpawner.dataproc_locations_list = "b,c"
 
 c.JupyterHub.log_level = 'DEBUG'
 
-# TODO(mayran): Move the handler into Python code
-# and properly log Component Gateway being None.
-# from jupyterhub.handlers.base import BaseHandler
-# from tornado.web import authenticated
-
-# class RedirectComponentGatewayHandler(BaseHandler):
-#   """ Handles redirect to notebook server after spawn.
-
-#   This only works when the spawn_pending page is displayed.
-#   For the next access, use the db that is updated by _handle_operation_done.
-#   """
-#   @authenticated
-#   async def get(self, user_name='', user_path=''):
-#     next_url = self.current_user.spawner.component_gateway_url
-#     if next_url:
-#       self.redirect(next_url)
-#     self.redirect('/404')
-
-# c.JupyterHub.extra_handlers = [
-#   (r"/redirect-component-gateway(/*)", RedirectComponentGatewayHandler),
-# ]
 c.JupyterHub.template_paths = ['/etc/jupyterhub/templates']
 EOT
 


### PR DESCRIPTION
- New proxy was not included the local jupyterhub_config file
- Fixes gitignore that created a file not found error.