### PR TITLE
Cluster image selection support

### DIFF
--- a/dataprocspawner/customize_cluster.py
+++ b/dataprocspawner/customize_cluster.py
@@ -109,13 +109,49 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
       </input>
     </div>"""
 
-  html_master_type = ""
+  html_cluster_image = """
+    <br />
+    <div class="form-group" name="versioning">
+      <label for="versioning"><h1>Versioning</h1></label>
+      <div>
+        <input onclick="document.getElementById('custom_image').disabled = true;"
+          type="radio" id="image-radio1" name="image_version" value="preview-debian10">
+        <label for="customRadio1">PREVIEW 2.0</label>
+      </div>
+      <div>
+        <input onclick="document.getElementById('custom_image').disabled = true;"
+          type="radio" id="image-radio2" name="image_version" value="1.5-debian10" checked>
+        <label for="customRadio2">1.5</label>
+      </div>
+      <div>
+        <input onclick="document.getElementById('custom_image').disabled = true;"
+          type="radio" id="image-radio3" name="image_version" value="1.4-debian10">
+        <label for="customRadio3">1.4</label>
+      </div>
+      <div>
+        <input onclick="document.getElementById('custom_image').disabled = true;"
+          type="radio" id="image-radio4" name="image_version" value="1.3-debian10">
+        <label for="customRadio4">1.3</label>
+      </div>
+      <div>
+        <input onclick="document.getElementById('custom_image').disabled = false;"
+          type="radio" id="image-radio5" name="image_version">
+        <label for="customRadio5">Custom image</label>
+        <input class="form-control" id="custom_image" name="custom_image"
+          placeholder="projects/<project_id>/global/images/<image_id>" disabled>
+      </div>
+    </div>"""
+
+  html_master_type = """
+    <br />
+    <div class="form-group" name="master">
+      <label for="master"><h1>Master node</h1></label>"""
   if node_types:
     html_master_type += """
-    <div class="form-group">
-      <label for="master_node_type">Master machine type</label>
-      <select class="form-control" name="master_node_type">
-        <option value=''>Default</option>"""
+      <div class="form-group">
+        <label for="master_node_type">Machine type</label>
+        <select class="form-control" name="master_node_type">
+          <option value=''>Default</option>"""
     for t in node_types:
       html_master_type += f'\n\t<option value="{t}">{t}</option>'
     html_master_type += """
@@ -124,7 +160,7 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
 
   html_master_disk_type = """
     <div class="form-group">
-      <label for="master_disk_type">Master disk type</label>
+      <label for="master_disk_type">Primary disk type</label>
       <select class="form-control" name="master_disk_type">
         <option value="pd-standard">Standard Persistent Disk</option>
         <option value="pd-ssd">SSD Persistent Disk</option>
@@ -133,15 +169,19 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
 
   html_master_disk_size = """
     <div class="form-group">
-      <label for="master_disk_size">Master disk size</label>
+      <label for="master_disk_size">Primary disk size</label>
       <input name="master_disk_size" class="form-control" placeholder="default" value=''></input>
+    </div>
     </div>"""
 
-  html_worker_type = ""
+  html_worker_type = """
+    <br />
+    <div class="form-group" name="worker">
+      <label for="worker"><h1>Worker nodes</h1></label>"""
   if node_types:
     html_worker_type += """
       <div class="form-group">
-        <label for="worker_node_type">Workers machine type</label>
+        <label for="worker_node_type">Machine type</label>
         <select class="form-control" name="worker_node_type">
           <option value=''>Default</option>"""
     for t in node_types:
@@ -152,7 +192,7 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
 
   html_worker_disk_type = """
     <div class="form-group">
-      <label for="worker_disk_type">Worker disk type</label>
+      <label for="worker_disk_type">Primary disk type</label>
       <select class="form-control" name="worker_disk_type">
         <option value="pd-standard">Standard Persistent Disk</option>
         <option value="pd-ssd">SSD Persistent Disk</option>
@@ -161,21 +201,74 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
 
   html_worker_disk_size = """
     <div class="form-group">
-      <label for="worker_disk_size">Worker disk size</label>
+      <label for="worker_disk_size">Primary disk size</label>
       <input name="worker_disk_size" class="form-control" placeholder="default" value=''></input>
     </div>"""
 
   html_worker_amount = """
     <div class="form-group">
-      <label for="worker_node_amount">Number of workers</label>
-      <input name="worker_node_amount" class="form-control" placeholder="default" value=''></input>
+      <label for="worker_node_amount">Number of worker nodes</label>
+      <input name="worker_node_amount" class="form-control" placeholder="" value='2'></input>
+    </div>
+    </div>"""
+
+  html_secondary_worker_preemptibility = """
+    <div class="form-group">
+      <label for="sec_worker_preempt">Preemptibility</label>
+      <select class="form-control" name="sec_worker_preempt">
+        <option value="PREEMPTIBLE">Preemptible</option>
+        <option value="NON-PREEMPTIBLE">Non-preemptible</option>
+      </select>
+    </div>"""
+
+  html_secondary_worker_disk_type = """
+    <br />
+    <div class="form-group" name="sec_worker">
+      <label for="sec_worker"><h1>Secondary worker nodes</h1></label>
+      <div class="form-group">
+        <label for="sec_worker_disk_type">Primary disk type</label>
+        <select class="form-control" name="sec_worker_disk_type">
+          <option value="pd-standard">Standard Persistent Disk</option>
+          <option value="pd-ssd">SSD Persistent Disk</option>
+        </select>
+      </div>"""
+
+  html_secondary_worker_disk_size = """
+    <div class="form-group">
+      <label for="sec_worker_disk_size">Primary disk size</label>
+      <input name="sec_worker_disk_size" class="form-control"
+        placeholder="default" value=''></input>
+    </div>"""
+
+  html_secondary_worker_amount = """
+    <div class="form-group">
+      <label for="sec_worker_node_amount">Number of secondary worker nodes</label>
+      <input name="sec_worker_node_amount" class="form-control" placeholder="" value='0'></input>
+    </div>
     </div>"""
 
   html_custom_labels = """
+    <br />
     <div class="form-group">
       <label for="custom_labels">User defined labels</label>
       <input name="custom_labels" class="form-control" placeholder="key1:value1,key2:value2"
         value=''>
+      </input>
+    </div>"""
+
+  html_init_actions = """
+    <div class="form-group">
+      <label for="init_actions">Initialization actions</label>
+      <input name="init_actions" class="form-control"
+        placeholder="gs://<init_action1>,gs://<init_action2>" value="">
+      </input>
+    </div>"""
+
+  html_cluster_properties = """
+    <div class="form-group">
+      <label for="cluster_properties">Cluster properties</label>
+      <input name="cluster_properties" class="form-control"
+        placeholder="prefix:property1=value1,prefix:property2=value2" value="">
       </input>
     </div>"""
 
@@ -201,6 +294,7 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
     html_autoscaling_policy,
     html_pip_packages,
     html_condo_packages,
+    html_cluster_image,
     html_master_type,
     html_master_disk_type,
     html_master_disk_size,
@@ -208,7 +302,14 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
     html_worker_disk_type,
     html_worker_disk_size,
     html_worker_amount,
+    # Temporary disabled
+    # html_secondary_worker_preemptibility,
+    html_secondary_worker_disk_type,
+    html_secondary_worker_disk_size,
+    html_secondary_worker_amount,
     html_custom_labels,
+    html_init_actions,
+    # html_cluster_properties,
     html_hive_settings
   ])
 

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -1102,6 +1102,19 @@ class DataprocSpawner(Spawner):
 
     return [z for z in zones.split(',') if z in region_zone_letters] or region_zone_letters
 
+  def _get_custom_image_version(self, custom_image):
+    project = custom_image.split('/')[1]
+    image = custom_image.split('/')[4]
+    try:
+      request = self.compute_client.images().get(project=project, image=image)
+      response = request.execute()
+      version = re.split(r'(-debian.*|-ubuntu.*)', response['labels']['goog-dataproc-version'])
+      goog_version = version[0].replace('-', '.') + version[1]
+    except Exception as e:
+      self.log.info(f'Failed to process Dataproc custom image version:\n\t{e}')
+
+    return goog_version
+
 
 ################################################################################
 # Cluster configuration
@@ -1162,22 +1175,36 @@ class DataprocSpawner(Spawner):
           }
       )
 
+    if self.user_options.get('init_actions'):
+      for init_action in self.user_options.get('init_actions').split(','):
+        if init_action.startswith('gs://'):
+          config['initialization_actions'].append(
+            {
+              'executable_file': init_action
+            }
+          )
+
+    if self.user_options.get('image_version'):
+      if self.user_options.get('custom_image'):
+        config['master_config']['image_uri'] = self.user_options.get('custom_image')
+        config['worker_config']['image_uri'] = self.user_options.get('custom_image')
+        config['software_config']['image_version'] = \
+          self._get_custom_image_version(self.user_options.get('custom_image'))
+      else:
+        config['software_config']['image_version'] = self.user_options.get('image_version')
+
     if self.user_options.get('master_node_type'):
-      config.setdefault('master_config', {})
       config['master_config']['machine_type_uri'] = self.user_options.get('master_node_type')
 
     if self.user_options.get('worker_node_type'):
-      config.setdefault('worker_config', {})
       config['worker_config']['machine_type_uri'] = self.user_options.get('worker_node_type')
 
     if self.user_options.get('master_disk_type'):
-      config.setdefault('master_config', {})
       config['master_config'].setdefault('disk_config', {})
       config['master_config']['disk_config']['boot_disk_type'] = \
         self.user_options.get('master_disk_type')
 
     if self.user_options.get('worker_disk_type'):
-      config.setdefault('worker_config', {})
       config['worker_config'].setdefault('disk_config', {})
       config['worker_config']['disk_config']['boot_disk_type'] = \
         self.user_options.get('worker_disk_type')
@@ -1187,7 +1214,6 @@ class DataprocSpawner(Spawner):
         val = int(self.user_options.get('master_disk_size'))
         if val < 15:
           val = 15
-        config.setdefault('master_config', {})
         config['master_config'].setdefault('disk_config', {})
         config['master_config']['disk_config']['boot_disk_size_gb'] = val
       except ValueError:
@@ -1198,7 +1224,6 @@ class DataprocSpawner(Spawner):
         val = int(self.user_options.get('worker_disk_size'))
         if val < 15:
           val = 15
-        config.setdefault('worker_config', {})
         config['worker_config'].setdefault('disk_config', {})
         config['worker_config']['disk_config']['boot_disk_size_gb'] = val
       except ValueError:
@@ -1209,10 +1234,31 @@ class DataprocSpawner(Spawner):
         val = int(self.user_options.get('worker_node_amount'))
         if val < 2:
           val = 2
-        config.setdefault('worker_config', {})
         config['worker_config']['num_instances'] = val
       except ValueError:
         pass
+
+    if self.user_options.get('sec_worker_disk_type'):
+      config.setdefault('secondary_worker_config', {})
+      config['secondary_worker_config'].setdefault('disk_config', {})
+      config['secondary_worker_config']['disk_config']['boot_disk_type'] = \
+        self.user_options.get('sec_worker_disk_type')
+
+    if self.user_options.get('sec_worker_disk_size'):
+      try:
+        val = int(self.user_options.get('sec_worker_disk_size'))
+        if val < 15:
+          val = 15
+        config.setdefault('secondary_worker_config', {})
+        config['secondary_worker_config'].setdefault('disk_config', {})
+        config['secondary_worker_config']['disk_config']['boot_disk_size_gb'] = val
+      except ValueError:
+        pass
+
+    if self.user_options.get('sec_worker_node_amount'):
+      config.setdefault('secondary_worker_config', {})
+      config['secondary_worker_config']['num_instances'] = \
+        int(self.user_options.get('sec_worker_node_amount'))
 
     autoscaling_policy = self.user_options.get('autoscaling_policy', '')
     if autoscaling_policy:
@@ -1280,6 +1326,7 @@ class DataprocSpawner(Spawner):
       # Defines default values if some key is not exists
       cluster_data['config'].setdefault('gce_cluster_config', {})
       cluster_data['config'].setdefault('master_config', {})
+      cluster_data['config'].setdefault('worker_config', {})
       cluster_data['config'].setdefault('initialization_actions', [])
       cluster_data['config'].setdefault('software_config', {})
       cluster_data['config']['software_config'].setdefault('properties', {})

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -1110,6 +1110,7 @@ class DataprocSpawner(Spawner):
   def _get_custom_image_version(self, custom_image):
     project = custom_image.split('/')[1]
     image = custom_image.split('/')[4]
+    goog_version = ''
     try:
       request = self.compute_client.images().get(project=project, image=image)
       response = request.execute()

--- a/docker/jupyterhub_config.py
+++ b/docker/jupyterhub_config.py
@@ -64,6 +64,7 @@ c.DataprocSpawner.dataproc_locations_list = os.environ.get('DATAPROC_LOCATIONS_L
 c.DataprocSpawner.machine_types_list = os.environ.get('DATAPROC_MACHINE_TYPES_LIST', '')
 c.DataprocSpawner.cluster_name_pattern = os.environ.get('CLUSTER_NAME_PATTERN', 'dataprochub-{}')
 c.DataprocSpawner.allow_custom_clusters = is_true(os.environ.get('DATAPROC_ALLOW_CUSTOM_CLUSTERS', ''))
+c.DataprocSpawner.allow_random_cluster_names = is_true(os.environ.get('ALLOW_RANDOM_CLUSTER_NAMES', ''))
 c.DataprocSpawner.gcs_notebooks = os.environ.get('GCS_NOTEBOOKS', '')
 if not c.DataprocSpawner.gcs_notebooks:
   c.DataprocSpawner.gcs_notebooks = os.environ.get('NOTEBOOKS_LOCATION', '')

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -600,6 +600,7 @@ class TestDataprocSpawner:
             'boot_disk_size_gb': 1000
           },
         },
+        'worker_config': {},
         'software_config': {
           'image_version': '1.4-debian9',
           'optional_components': [


### PR DESCRIPTION
Now the user can select image version or provide custom image for the cluster.
Initialization-actions support has been added.
Secondary worker config has been added, though nodes are always preemptible.
Variable ALLOW_RANDOM_CLUSTER_NAMES has been added to Jupyterhub config.