### PR TITLE
Don't set default subnet URI if network URI is set in the cluster config

### DIFF
--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -1307,7 +1307,8 @@ class DataprocSpawner(Spawner):
         metadata = cluster_data['config']['gce_cluster_config']['metadata']
 
       # Sets default network for the cluster if not already provided in YAML.
-      if 'subnetwork_uri' not in cluster_data['config']['gce_cluster_config']:
+      if ('network_uri' not in cluster_data['config']['gce_cluster_config'] and
+          'subnetwork_uri' not in cluster_data['config']['gce_cluster_config']):
         if self.dataproc_default_subnet:
           (cluster_data['config']['gce_cluster_config']
            ['subnetwork_uri']) = self.dataproc_default_subnet

--- a/docker/jupyterhub.sh
+++ b/docker/jupyterhub.sh
@@ -217,9 +217,10 @@ function set-default-configs() {
 function set-default-name-pattern() {
   if [ -z "${CLUSTER_NAME_PATTERN}" ];
   then
-    default_name_pattern="dataprochub-$( curl -s ${metadata_base_url}/instance/name -H "Metadata-Flavor: Google" )-{}"
+    default_name_pattern="dataprochub-{}"
     echo "Default name pattern not specified. Setting default name pattern to ${default_name_pattern}"
     export CLUSTER_NAME_PATTERN="${default_name_pattern}"
+    export ALLOW_RANDOM_CLUSTER_NAMES="true"
   fi
 }
 

--- a/docker/jupyterhub.sh
+++ b/docker/jupyterhub.sh
@@ -217,10 +217,9 @@ function set-default-configs() {
 function set-default-name-pattern() {
   if [ -z "${CLUSTER_NAME_PATTERN}" ];
   then
-    default_name_pattern="dataprochub-{}"
+    default_name_pattern="hub-$( curl -s ${metadata_base_url}/instance/name -H "Metadata-Flavor: Google" )-{}"
     echo "Default name pattern not specified. Setting default name pattern to ${default_name_pattern}"
     export CLUSTER_NAME_PATTERN="${default_name_pattern}"
-    export ALLOW_RANDOM_CLUSTER_NAMES="true"
   fi
 }
 

--- a/docker/jupyterhub_config.py
+++ b/docker/jupyterhub_config.py
@@ -65,6 +65,7 @@ c.DataprocSpawner.dataproc_locations_list = os.environ.get('DATAPROC_LOCATIONS_L
 c.DataprocSpawner.machine_types_list = os.environ.get('DATAPROC_MACHINE_TYPES_LIST', '')
 c.DataprocSpawner.cluster_name_pattern = os.environ.get('CLUSTER_NAME_PATTERN', 'dataprochub-{}')
 c.DataprocSpawner.allow_custom_clusters = is_true(os.environ.get('DATAPROC_ALLOW_CUSTOM_CLUSTERS', ''))
+c.DataprocSpawner.allow_random_cluster_names = is_true(os.environ.get('ALLOW_RANDOM_CLUSTER_NAMES', ''))
 c.DataprocSpawner.gcs_notebooks = os.environ.get('GCS_NOTEBOOKS', '')
 if not c.DataprocSpawner.gcs_notebooks:
   c.DataprocSpawner.gcs_notebooks = os.environ.get('NOTEBOOKS_LOCATION', '')

--- a/tests/test_data/basic_with_network.yaml
+++ b/tests/test_data/basic_with_network.yaml
@@ -1,0 +1,46 @@
+clusterName: 'overwrite'
+config:
+  gceClusterConfig:
+    networkUri: default
+    metadata:
+      m1: "v1"
+      m2: "v2"
+  initializationActions:
+  - executableFile: gs://dataproc-initialization-actions/python/pip-install.sh
+  softwareConfig:
+    properties:
+      dataproc:jupyter.hub.args: 'test-args-str-yaml'
+      dataproc:jupyter.notebook.gcs.dir: ''
+      dataproc:jupyter.hub.env: 'test-env-str-yaml'
+  masterConfig:
+    numInstances: 1
+    machineTypeUri: n1-standard-4
+    diskConfig:
+      bootDiskType: pd-standard
+      bootDiskSizeGb: 500
+      numLocalSsds: 0
+    accelerators:
+    - acceleratorTypeUri: nvidia-tesla-v100
+      acceleratorCount: 1
+    machineTypeUri: n1-standard-4
+    minCpuPlatform: AUTOMATIC
+    imageUri: projects/test-project/global/images/test-image
+  workerConfig:
+    diskConfig:
+      bootDiskSizeGb: 1000
+      bootDiskType: pd-standard
+      numLocalSsds: 2
+    imageUri: projects/test-project/global/images/test-image
+    machineTypeUri: n1-highmem-16
+    minCpuPlatform: AUTOMATIC
+    numInstances: 5
+    preemptibility: NON_PREEMPTIBLE
+  secondaryWorkerConfig:
+    diskConfig:
+      bootDiskSizeGb: 100
+      bootDiskType: pd-standard
+    imageUri: projects/test-project/global/images/test-image
+    machineTypeUri: n1-standard-4
+    minCpuPlatform: AUTOMATIC
+    numInstances: 2
+    isPreemptible: true


### PR DESCRIPTION
This avoids errors if the cluster definition already specified a network
URI. Also enables cluster name randomization and shortens the name
pattern to avoid cluster names becoming too long.