### PR TITLE
Fix multiple bugs related to image version handling

### DIFF
--- a/dataprocspawner/customize_cluster.py
+++ b/dataprocspawner/customize_cluster.py
@@ -129,11 +129,6 @@ def get_custom_cluster_html_form(autoscaling_policies, node_types):
         <label for="customRadio3">1.4</label>
       </div>
       <div>
-        <input onclick="document.getElementById('custom_image').disabled = true;"
-          type="radio" id="image-radio4" name="image_version" value="1.3-debian10">
-        <label for="customRadio4">1.3</label>
-      </div>
-      <div>
         <input onclick="document.getElementById('custom_image').disabled = false;"
           type="radio" id="image-radio5" name="image_version">
         <label for="customRadio5">Custom image</label>

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -1433,10 +1433,10 @@ class DataprocSpawner(Spawner):
     cluster_data['config']['software_config'].setdefault('optional_components', [])
     # Converts component's string to its int value (See Component protobuf in
     # google-cloud-dataproc library). This allows to pass strings in yaml.
-    optional_components = set([
+    optional_components = {
         Component[c].value if isinstance(c, str) else c for
         c in cluster_data['config']['software_config']['optional_components']
-    ])
+    }
 
     if self.force_add_jupyter_component:
       if Component['JUPYTER'].value not in optional_components:

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -1057,9 +1057,9 @@ class DataprocSpawner(Spawner):
     order for Jupyter to work correctly."""
     parts = image_version.split('-')
 
-    if parts[0].lower() == "preview":
+    if parts[0].lower() == 'preview':
       return False
-    elif parts[0] == "2.0.0":
+    elif parts[0] == '2.0.0':
       if len(parts) < 3:
         return False
       if parts[1] in [f'RC{i}' for i in range(1, 12)]:
@@ -1416,7 +1416,8 @@ class DataprocSpawner(Spawner):
                  ['dataproc:jupyter.hub.env']) = self.env_str
     (cluster_data['config']['software_config']['properties']
                  ['dataproc:jupyter.hub.menu.enabled']) = 'true'
-    cluster_data['config']['software_config']['properties'].pop('dataproc:jupyter.hub.enabled', None)
+    (cluster_data['config']['software_config']['properties']
+                 .pop('dataproc:jupyter.hub.enabled', None))
 
     if self.gcs_user_folder:
       (cluster_data['config']['software_config']['properties']
@@ -1437,7 +1438,6 @@ class DataprocSpawner(Spawner):
         c in cluster_data['config']['software_config']['optional_components']
     ]
 
-    image_version = cluster_data['config']['software_config']['image_version']
     if self.force_add_jupyter_component:
       if Component['JUPYTER'].value not in optional_components:
         optional_components.append(Component['JUPYTER'].value)

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -1433,22 +1433,25 @@ class DataprocSpawner(Spawner):
     cluster_data['config']['software_config'].setdefault('optional_components', [])
     # Converts component's string to its int value (See Component protobuf in
     # google-cloud-dataproc library). This allows to pass strings in yaml.
-    optional_components = [
+    optional_components = set([
         Component[c].value if isinstance(c, str) else c for
         c in cluster_data['config']['software_config']['optional_components']
-    ]
+    ])
 
     if self.force_add_jupyter_component:
       if Component['JUPYTER'].value not in optional_components:
-        optional_components.append(Component['JUPYTER'].value)
+        optional_components.add(Component['JUPYTER'].value)
       # preview (2.x) images and up do not support Anaconda
       if self._image_version_supports_anaconda(
           cluster_data['config']['software_config']['image_version']):
         if Component['ANACONDA'].value not in optional_components:
-          optional_components.append(Component['ANACONDA'].value)
+          optional_components.add(Component['ANACONDA'].value)
+      else:
+        if Component['ANACONDA'].value in optional_components:
+          optional_components.remove(Component['ANACONDA'].value)
 
     cluster_data['config']['software_config']['optional_components'] = (
-        optional_components
+        list(optional_components)
     )
 
     # Ensures that durations match the Protobuf format ({seconds:300, nanos:0})

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -1425,6 +1425,7 @@ class DataprocSpawner(Spawner):
                  ['dataproc:jupyter.hub.env']) = self.env_str
     (cluster_data['config']['software_config']['properties']
                  ['dataproc:jupyter.hub.menu.enabled']) = 'true'
+    cluster_data['config']['software_config']['properties'].pop('dataproc:jupyter.hub.enabled', None)
 
     if self.gcs_user_folder:
       (cluster_data['config']['software_config']['properties']

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -1049,39 +1049,30 @@ class DataprocSpawner(Spawner):
             'your admnistrator.')
     return uri_geo or uri
 
-  def _validate_image_version_supports_component_gateway(self, image_version):
-    """Validate whether given image version supports Component Gateway.
+  def _image_version_supports_anaconda(self, image_version):
+    """Validate whether given image version supports Anaconda.
 
-    Earlier image versions do not support CG with JupyterHub. This function
-    takes a Dataproc image version specification like `1.3.25-debian9` or `1.5`
-    and returns whether Component Gateway is supported.
-    """
-    # Map minor version to minimum subminor that supports CG with JupyterHub
-    min_supported_images = {
-        '1.3': 59,
-        '1.4': 30,
-        '1.5': 5,
-        '2.0': 0
-    }
-    version = image_version.split('-')[0]
+    Preview images after 2.0.0-RC12 do not support Anaconda.
+    For older versions, we force Anaconda to be activated in
+    order for Jupyter to work correctly."""
+    parts = image_version.split('-')
 
-    # Extract minor and subminor versions ('1.3.5' -> '1.3', 5)
-    if len(version.split('.')) < 3:
-      # Subminor version not specified, head images always support CG
-      return True
+    if parts[0].lower() == "preview":
+      return False
+    elif parts[0] == "2.0.0":
+      if len(parts) < 3:
+        return False
+      if parts[1] in [f'RC{i}' for i in range(1, 12)]:
+        return True
+
     try:
-      subminor_version = int(version.split('.')[2])
+      major_version = int(parts[0].split('.')[0])
     except ValueError as e:
       self.log.warning('Failed to parse image version "%s": %s' % (image_version, e))
       # Something weird is going on with image version format, fail open
       return True
 
-    minor_version = '.'.join(version.split('.')[:2])
-    if minor_version in min_supported_images:
-      return subminor_version >= min_supported_images[minor_version]
-
-    # Unrecognized minor version, fail open
-    return True
+    return major_version < 2
 
   def _list_to_dict(self, rlist):
     """ Converts list of user defined labels to dictionary. """
@@ -1435,10 +1426,6 @@ class DataprocSpawner(Spawner):
       cluster_data['config']['software_config']['image_version'] = '1.4-debian9'
 
     # Forces Component Gateway
-    if not self._validate_image_version_supports_component_gateway(
-        cluster_data['config']['software_config']['image_version']):
-      self._raise_exception('Image version does not support Component Gateway.')
-
     cluster_data['config'].setdefault('endpoint_config', {})
     cluster_data['config']['endpoint_config']['enable_http_port_access'] = True
 
@@ -1450,11 +1437,15 @@ class DataprocSpawner(Spawner):
         c in cluster_data['config']['software_config']['optional_components']
     ]
 
+    image_version = cluster_data['config']['software_config']['image_version']
     if self.force_add_jupyter_component:
       if Component['JUPYTER'].value not in optional_components:
         optional_components.append(Component['JUPYTER'].value)
-      if Component['ANACONDA'].value not in optional_components:
-        optional_components.append(Component['ANACONDA'].value)
+      # preview (2.x) images and up do not support Anaconda
+      if self._image_version_supports_anaconda(
+          cluster_data['config']['software_config']['image_version']):
+        if Component['ANACONDA'].value not in optional_components:
+          optional_components.append(Component['ANACONDA'].value)
 
     cluster_data['config']['software_config']['optional_components'] = (
         optional_components

--- a/tests/test_data/basic.yaml
+++ b/tests/test_data/basic.yaml
@@ -12,6 +12,7 @@ config:
       dataproc:jupyter.hub.args: 'test-args-str-yaml'
       dataproc:jupyter.notebook.gcs.dir: ''
       dataproc:jupyter.hub.env: 'test-env-str-yaml'
+      dataproc:jupyter.hub.enabled: 'true'
   masterConfig:
     numInstances: 1
     machineTypeUri: n1-standard-4

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -491,6 +491,8 @@ class TestDataprocSpawner:
 
     assert config_built['config']['software_config']['properties']['dataproc:jupyter.hub.args'] == 'test-args-str'
     assert config_built['config']['software_config']['properties']['dataproc:jupyter.hub.env'] == 'test-env-str'
+    assert config_built['config']['software_config']['properties']['dataproc:jupyter.hub.menu.enabled'] == 'true'
+    assert 'dataproc:jupyter.hub.enabled' not in config_built['config']['software_config']['properties']
 
   def test_cluster_definition_overrides(self, monkeypatch):
     """Check that config settings incompatible with JupyterHub are overwritten correctly."""

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -372,7 +372,18 @@ class TestDataprocSpawner:
 
     def test_read_file(*args, **kwargs):
       config_string = open('./tests/test_data/minimum.yaml', 'r').read()
+      print(config_string)
       return config_string
+
+    def test_read_file_preview(*args, **kwargs):
+      config_string = open('./tests/test_data/minimum.yaml', 'r').read()
+      config_string = config_string.replace('1.4.16', 'preview')
+      print(config_string)
+      return config_string
+
+    def test_read_file_2_0(*args, **kwargs):
+      config_string = open('./tests/test_data/minimum.yaml', 'r').read()
+      return config_string.replace('1.4.16', '2.0.0-RC19')
 
     def test_clustername(*args, **kwargs):
       return 'test-clustername'
@@ -409,6 +420,22 @@ class TestDataprocSpawner:
 
     assert 'dataproc:jupyter.hub.args' in config_built['config']['software_config']['properties']
     assert 'dataproc:jupyter.hub.env' in config_built['config']['software_config']['properties']
+
+    spawner.user_options = {
+      'cluster_type': 'minimum.yaml',
+    }
+    monkeypatch.setattr(spawner, "read_gcs_file", test_read_file_preview)
+
+    config_built = spawner._build_cluster_config()
+    print(config_built)
+    assert Component['JUPYTER'].value in config_built['config']['software_config']['optional_components']
+    assert Component['ANACONDA'].value not in config_built['config']['software_config']['optional_components']
+
+    monkeypatch.setattr(spawner, "read_gcs_file", test_read_file_2_0)
+
+    config_built = spawner._build_cluster_config()
+    assert Component['JUPYTER'].value in config_built['config']['software_config']['optional_components']
+    assert Component['ANACONDA'].value not in config_built['config']['software_config']['optional_components']
 
   def test_cluster_definition_check_core_fields(self, monkeypatch):
     """ Values chosen by the user through the form overwrites others. If the
@@ -853,7 +880,7 @@ class TestDataprocSpawner:
     assert config_built['config']['secondary_worker_config']['machine_type_uri'] == 'n1-standard-4'
     assert config_built['config']['master_config']['accelerators'][0]['accelerator_type_uri'] == 'nvidia-tesla-v100'
 
-  def test_image_version_supports_component_gateway(self):
+  def test_image_version_supports_anaconda(self):
     fake_creds = AnonymousCredentials()
     mock_dataproc_client = mock.create_autospec(ClusterControllerClient(credentials=fake_creds))
     mock_gcs_client = mock.create_autospec(storage.Client(credentials=fake_creds, project='project'))
@@ -863,24 +890,31 @@ class TestDataprocSpawner:
     spawner = DataprocSpawner(hub=Hub(), dataproc=mock_dataproc_client, gcs=mock_gcs_client,
                               user=MockUser(), _mock=True, gcs_notebooks=self.gcs_notebooks,
                               compute=mock_compute_client, project='test-project')
-    assert spawner._validate_image_version_supports_component_gateway('1.3') is True
-    assert spawner._validate_image_version_supports_component_gateway('1.3-debian9') is True
-    assert spawner._validate_image_version_supports_component_gateway('1.3.6-debian9') is False
-    assert spawner._validate_image_version_supports_component_gateway('1.3.59-debian9') is True
-    assert spawner._validate_image_version_supports_component_gateway('1.3.999-debian9') is True
-    assert spawner._validate_image_version_supports_component_gateway('1.4-debian10') is True
-    assert spawner._validate_image_version_supports_component_gateway('1.4.6-debian10') is False
-    assert spawner._validate_image_version_supports_component_gateway('1.4.31-debian10') is True
-    assert spawner._validate_image_version_supports_component_gateway('1.5-debian10') is True
-    assert spawner._validate_image_version_supports_component_gateway('1.5.0-debian10') is False
-    assert spawner._validate_image_version_supports_component_gateway('1.5.5-debian10') is True
-    assert spawner._validate_image_version_supports_component_gateway('2') is True
-    assert spawner._validate_image_version_supports_component_gateway('2.0') is True
-    assert spawner._validate_image_version_supports_component_gateway('2.0.0') is True
-    assert spawner._validate_image_version_supports_component_gateway('2.3.0') is True
-    assert spawner._validate_image_version_supports_component_gateway('2.0.0-RC1-preview') is True
-    assert spawner._validate_image_version_supports_component_gateway('weird-unexpected-version-124.3.v2.2020-02-15') is True
-    assert spawner._validate_image_version_supports_component_gateway('1.3.weird-version-again') is True
+    assert spawner._image_version_supports_anaconda('1.3') is True
+    assert spawner._image_version_supports_anaconda('1.3-debian9') is True
+    assert spawner._image_version_supports_anaconda('1.3.6-debian9') is True
+    assert spawner._image_version_supports_anaconda('1.3.59-debian9') is True
+    assert spawner._image_version_supports_anaconda('1.3.999-debian9') is True
+    assert spawner._image_version_supports_anaconda('1.4-debian10') is True
+    assert spawner._image_version_supports_anaconda('1.4.6-debian10') is True
+    assert spawner._image_version_supports_anaconda('1.4.31-debian10') is True
+    assert spawner._image_version_supports_anaconda('1.5-debian10') is True
+    assert spawner._image_version_supports_anaconda('1.5.0-debian10') is True
+    assert spawner._image_version_supports_anaconda('1.5.5-debian10') is True
+    assert spawner._image_version_supports_anaconda('2') is False
+    assert spawner._image_version_supports_anaconda('2.0') is False
+    assert spawner._image_version_supports_anaconda('2.0-ubuntu18') is False
+    assert spawner._image_version_supports_anaconda('2.0.0') is False
+    assert spawner._image_version_supports_anaconda('2.0.0-debian10') is False
+    assert spawner._image_version_supports_anaconda('2.0.1') is False
+    assert spawner._image_version_supports_anaconda('2.3.0') is False
+    assert spawner._image_version_supports_anaconda('2.0.0-RC1-debian10') is True
+    assert spawner._image_version_supports_anaconda('2.0.0-RC7-debian10') is True
+    assert spawner._image_version_supports_anaconda('2.0.0-RC11-debian10') is True
+    assert spawner._image_version_supports_anaconda('2.0.0-RC12-debian10') is False
+    assert spawner._image_version_supports_anaconda('2.0.0-RC77-debian10') is False
+    assert spawner._image_version_supports_anaconda('weird-unexpected-version-124.3.v2.2020-02-15') is True
+    assert spawner._image_version_supports_anaconda('1.3.weird-version-again') is True
 
   def test_validate_proto(self, monkeypatch):
     import yaml

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -385,6 +385,12 @@ class TestDataprocSpawner:
       config_string = open('./tests/test_data/minimum.yaml', 'r').read()
       return config_string.replace('1.4.16', '2.0.0-RC19')
 
+    def test_read_file_2_0_with_anaconda(*args, **kwargs):
+      config_string = open('./tests/test_data/minimum.yaml', 'r').read()
+      config_string = config_string.replace('1.4.16', '2.0.0-RC19')
+      config_string += "\n    optionalComponents:\n    - JUPYTER\n    - ANACONDA\n"
+      return config_string
+
     def test_clustername(*args, **kwargs):
       return 'test-clustername'
 
@@ -432,6 +438,12 @@ class TestDataprocSpawner:
     assert Component['ANACONDA'].value not in config_built['config']['software_config']['optional_components']
 
     monkeypatch.setattr(spawner, "read_gcs_file", test_read_file_2_0)
+
+    config_built = spawner._build_cluster_config()
+    assert Component['JUPYTER'].value in config_built['config']['software_config']['optional_components']
+    assert Component['ANACONDA'].value not in config_built['config']['software_config']['optional_components']
+
+    monkeypatch.setattr(spawner, "read_gcs_file", test_read_file_2_0_with_anaconda)
 
     config_built = spawner._build_cluster_config()
     assert Component['JUPYTER'].value in config_built['config']['software_config']['optional_components']


### PR DESCRIPTION
* Image version 1.3 is not supported and should not be listed
* Always unset `dataproc:jupyter.hub.enabled` so Jupyter endpoint is visible
* Don't check for Component Gateway compatibility now that we don't the property above: Dataproc's frontend capability enforcement will do that for us
* Do check for Anaconda compatibility with preview image versions: newer preview images do *not* require or support ANACONDA anymore.