### PR TITLE
Fixing Component Gateway URL being seen as None

### DIFF
--- a/dataprochub/app.py
+++ b/dataprochub/app.py
@@ -38,9 +38,9 @@ class DataprocHubUserUrlHandler(UserUrlHandler):
     self.log.info(f'# spawner._server value is {tmp_spawner_server}')
     if type(tmp_spawner_server) == Server:
       self.log.debug('# spawner._server is a Server')
-      redirect_url_parts = tmp_spawner_server.url.split('/')
-      redirect_url = '/'.join(redirect_url_parts[:-3])
-      redirect_url = f'{redirect_url}/jupyter/lab'
+      scheme, url =  tmp_spawner_server.url.split('://')
+      redirect_url = url.split('/')[0]
+      redirect_url = f'{scheme}://{redirect_url}/jupyter/lab'
     else:
       self.log.debug('# spawner._server is most likely a DataprocHubServer')
       redirect_url = tmp_spawner.component_gateway_url

--- a/dataprochub/app.py
+++ b/dataprochub/app.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """ Replaces default JupyterHub.app to handle redirects. """
-
+import re
 from jupyterhub.app import JupyterHub
 from jupyterhub.handlers.base import UserUrlHandler
 from jupyterhub.objects import Server
@@ -38,9 +38,8 @@ class DataprocHubUserUrlHandler(UserUrlHandler):
     self.log.info(f'# spawner._server value is {tmp_spawner_server}')
     if type(tmp_spawner_server) == Server:
       self.log.debug('# spawner._server is a Server')
-      scheme, url =  tmp_spawner_server.url.split('://')
-      redirect_url = url.split('/')[0]
-      redirect_url = f'{scheme}://{redirect_url}/jupyter/lab'
+      url_parts = re.search('(.+?)://(.+?)/(.+?)', tmp_spawner_server.url)
+      redirect_url = f'{url_parts.group(1)}://{url_parts.group(2)}/jupyter/lab'
     else:
       self.log.debug('# spawner._server is most likely a DataprocHubServer')
       redirect_url = tmp_spawner.component_gateway_url

--- a/dataprochub/app.py
+++ b/dataprochub/app.py
@@ -18,6 +18,7 @@ from jupyterhub.app import JupyterHub
 from jupyterhub.handlers.base import UserUrlHandler
 from jupyterhub.objects import Server
 
+
 class DataprocHubUserUrlHandler(UserUrlHandler):
   """ Extends UserUrlHandler to redirect user once spawn is done. """
 
@@ -32,9 +33,6 @@ class DataprocHubUserUrlHandler(UserUrlHandler):
     #   url=https://<CG_URL>:443/user/matthieum/,
     #   bind_url=https://<CG_URL>:443/user/matthieum/
     # )
-    # TODO(mayran): Check if when it's a Server, it can cause problems with re-
-    # adding routes or deleting the wrong ones.If so, we might need to overwrite
-    # `check_routes` in JupyterHub proxy.py
     self.log.info(f'# spawner._server value is {tmp_spawner_server}')
     if type(tmp_spawner_server) == Server:
       self.log.debug('# spawner._server is a Server')

--- a/dataprochub/app.py
+++ b/dataprochub/app.py
@@ -16,15 +16,35 @@
 
 from jupyterhub.app import JupyterHub
 from jupyterhub.handlers.base import UserUrlHandler
-
+from jupyterhub.objects import Server
 
 class DataprocHubUserUrlHandler(UserUrlHandler):
   """ Extends UserUrlHandler to redirect user once spawn is done. """
 
   async def _redirect_to_user_server(self, user, spawner):
     self.statsd.incr('redirects.user_after_login')
-    redirect_url = user.spawners[spawner.name].component_gateway_url
-    self.log.debug(f'# spawner.name is `{spawner.name}`.')
+    redirect_url = None
+    tmp_spawner = user.spawners[spawner.name]
+    tmp_spawner_server = tmp_spawner._server
+    # When restarting the Docker container, spawner._server is a Server instead
+    # of being a DataprocHubServer. We extract the component_gateway_url from
+    # that Server(
+    #   url=https://<CG_URL>:443/user/matthieum/,
+    #   bind_url=https://<CG_URL>:443/user/matthieum/
+    # )
+    # TODO(mayran): Check if when it's a Server, it can cause problems with re-
+    # adding routes or deleting the wrong ones.If so, we might need to overwrite
+    # `check_routes` in JupyterHub proxy.py
+    self.log.info(f'# spawner._server value is {tmp_spawner_server}')
+    if type(tmp_spawner_server) == Server:
+      self.log.debug('# spawner._server is a Server')
+      redirect_url_parts = tmp_spawner_server.url.split('/')
+      redirect_url = '/'.join(redirect_url_parts[:-3])
+      redirect_url = f'{redirect_url}/jupyter/lab'
+    else:
+      self.log.debug('# spawner._server is most likely a DataprocHubServer')
+      redirect_url = tmp_spawner.component_gateway_url
+
     self.log.info(f'# Redirecting to notebook at {redirect_url}.')
     self.redirect(redirect_url)
 

--- a/dataprochub/app.py
+++ b/dataprochub/app.py
@@ -14,6 +14,7 @@
 
 """ Replaces default JupyterHub.app to handle redirects. """
 import re
+
 from jupyterhub.app import JupyterHub
 from jupyterhub.handlers.base import UserUrlHandler
 from jupyterhub.objects import Server
@@ -27,19 +28,12 @@ class DataprocHubUserUrlHandler(UserUrlHandler):
     redirect_url = None
     tmp_spawner = user.spawners[spawner.name]
     tmp_spawner_server = tmp_spawner._server
-    # When restarting the Docker container, spawner._server is a Server instead
-    # of being a DataprocHubServer. We extract the component_gateway_url from
-    # that Server(
-    #   url=https://<CG_URL>:443/user/matthieum/,
-    #   bind_url=https://<CG_URL>:443/user/matthieum/
-    # )
+    self.log.debug(f'# spawners are {user.spawners}')
     self.log.info(f'# spawner._server value is {tmp_spawner_server}')
     if type(tmp_spawner_server) == Server:
-      self.log.debug('# spawner._server is a Server')
       url_parts = re.search('(.+?)://(.+?)/(.+?)', tmp_spawner_server.url)
       redirect_url = f'{url_parts.group(1)}://{url_parts.group(2)}/jupyter/lab'
     else:
-      self.log.debug('# spawner._server is most likely a DataprocHubServer')
       redirect_url = tmp_spawner.component_gateway_url
 
     self.log.info(f'# Redirecting to notebook at {redirect_url}.')

--- a/dataprochub/app.py
+++ b/dataprochub/app.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 """ Replaces default JupyterHub.app to handle redirects. """
+
 import re
 
+from dataprocspawner.spawnable import DataprocHubServer
 from jupyterhub.app import JupyterHub
 from jupyterhub.handlers.base import UserUrlHandler
 from jupyterhub.objects import Server
@@ -27,14 +29,18 @@ class DataprocHubUserUrlHandler(UserUrlHandler):
     self.statsd.incr('redirects.user_after_login')
     redirect_url = None
     tmp_spawner = user.spawners[spawner.name]
-    tmp_spawner_server = tmp_spawner._server
+    tmp_spawner_server = tmp_spawner.server
     self.log.debug(f'# spawners are {user.spawners}')
-    self.log.info(f'# spawner._server value is {tmp_spawner_server}')
-    if type(tmp_spawner_server) == Server:
+    self.log.info(f'# spawner.server value is {tmp_spawner_server}')
+    if isinstance(tmp_spawner_server, DataprocHubServer):
+      self.log.info('# Read component gateway url from DataprocHubServer.')
+      redirect_url = tmp_spawner.component_gateway_url
+    elif isinstance(tmp_spawner_server, Server):
+      self.log.info('# Make component gateway url from Server url.')
       url_parts = re.search('(.+?)://(.+?)/(.+?)', tmp_spawner_server.url)
       redirect_url = f'{url_parts.group(1)}://{url_parts.group(2)}/jupyter/lab'
     else:
-      redirect_url = tmp_spawner.component_gateway_url
+      self.log.info('# Can not type identify spawner server.')
 
     self.log.info(f'# Redirecting to notebook at {redirect_url}.')
     self.redirect(redirect_url)

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -422,6 +422,7 @@ class DataprocSpawner(Spawner):
     self.log.info(f'start_notebook_cmd is: {start_notebook_cmd}')
 
     # Server needs default values even if user.py>spawn uses dynamic ones.
+    # base_url gets overwritten.
     orm_server = orm.Server(
         proto='https',
         ip=self.component_gateway_url,

--- a/examples/deploy_local.sh
+++ b/examples/deploy_local.sh
@@ -28,7 +28,7 @@ cp ~/.config/gcloud/legacy_credentials/"${USER_EMAIL}"/adc.json /tmp/keys/applic
 GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/application_default_credentials.json
 
 # Builds
-docker build -t "${DOCKER_IMAGE}" -f docker/Dockerfile .
+docker build -t "${DOCKER_IMAGE}" -f docker/Dockerfile . --no-cache
 
 # Runs
 # For named servers, add -e HUB_ALLOW_NAMED_SERVERS="True"

--- a/examples/deploy_local.sh
+++ b/examples/deploy_local.sh
@@ -28,7 +28,7 @@ cp ~/.config/gcloud/legacy_credentials/"${USER_EMAIL}"/adc.json /tmp/keys/applic
 GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/application_default_credentials.json
 
 # Builds
-docker build -t "${DOCKER_IMAGE}" -f docker/Dockerfile . --no-cache
+docker build -t "${DOCKER_IMAGE}" -f docker/Dockerfile .
 
 # Runs
 # For named servers, add -e HUB_ALLOW_NAMED_SERVERS="True"


### PR DESCRIPTION
Extract the Compotenent Gateway URL from the Server instance to prevent redirect failure when container restarts.