### PR TITLE
Fix name show_spawned_clusters_in_notebooks_list

### DIFF
--- a/docker/jupyterhub_config.py
+++ b/docker/jupyterhub_config.py
@@ -66,7 +66,7 @@ c.DataprocSpawner.machine_types_list = os.environ.get('DATAPROC_MACHINE_TYPES_LI
 c.DataprocSpawner.cluster_name_pattern = os.environ.get('CLUSTER_NAME_PATTERN', 'dataprochub-{}')
 c.DataprocSpawner.allow_custom_clusters = is_true(os.environ.get('DATAPROC_ALLOW_CUSTOM_CLUSTERS', ''))
 c.DataprocSpawner.allow_random_cluster_names = is_true(os.environ.get('ALLOW_RANDOM_CLUSTER_NAMES', ''))
-c.DataprocSpawner.show_spawned_clusters_in_notebooks_ui = is_true(os.environ.get('SHOW_SPAWNED_CLUSTERS', ''))
+c.DataprocSpawner.show_spawned_clusters_in_notebooks_list = is_true(os.environ.get('SHOW_SPAWNED_CLUSTERS', ''))
 c.DataprocSpawner.gcs_notebooks = os.environ.get('GCS_NOTEBOOKS', '')
 if not c.DataprocSpawner.gcs_notebooks:
   c.DataprocSpawner.gcs_notebooks = os.environ.get('NOTEBOOKS_LOCATION', '')

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -559,7 +559,7 @@ class TestDataprocSpawner:
     monkeypatch.setattr(spawner, "read_gcs_file", test_read_file)
     monkeypatch.setattr(spawner, "clustername", test_clustername)
 
-    spawner.show_spawned_clusters_in_notebooks_ui = False
+    spawner.show_spawned_clusters_in_notebooks_list = False
     spawner.region = "us-east1"
     spawner.zone = "us-east1-d"
     spawner.env_str = "test-env-str"


### PR DESCRIPTION
It seems that there is a mismatch in the name for a single parameter across files.

```
[W 2020-12-11 11:58:08.142 DataprocHub configurable:190] Config option `show_spawned_clusters_in_notebooks_ui` not recognized by `DataprocSpawner`.  Did you mean `show_spawned_clusters_in_notebooks_list`?
/usr/local/lib/python3.7/dist-packages/requests/utils.py:179: RuntimeWarning: coroutine 'Template.render_async' was never awaited
  from netrc import netrc, NetrcParseError
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

This PR, updates the name to `show_spawned_clusters_in_notebooks_list` across all files.