### PR TITLE
Fixes container restart crashloop

### DIFF
--- a/docker/jupyterhub.sh
+++ b/docker/jupyterhub.sh
@@ -48,10 +48,13 @@ EOT
 function append-to-jupyterhub-config {
   # Adding this to prevent the Hub container to crash loop.
   # Without the rm, the crash loop still happens.
-  pid=$(cat /jupyterhub-proxy.pid)
-  kill -9 "${pid}"
-  rm /jupyterhub-proxy.pid
-  echo "Just killed ${pid}."
+  proxy_file=/jupyterhub-proxy.pid
+  if test -f "$proxy_file"; then
+    pid=$(cat ${proxy_file})
+    kill -9 "${pid}"
+    rm ${proxy_file}
+    echo "Just killed ${pid}."
+  fi
 
   # Checks if runs on AI Notebook by reading a metadata passed as an environment variable.
   jupyterhub_host_type=$( curl ${metadata_base_url}/instance/attributes/jupyterhub-host-type -H "Metadata-Flavor: Google" )

--- a/docker/jupyterhub.sh
+++ b/docker/jupyterhub.sh
@@ -46,6 +46,12 @@ EOT
 # and appends the proper configuration to jupyterhub_config.py.
 # For tries, GCE or local can use the default jupyterhub_config.py
 function append-to-jupyterhub-config {
+  # Adding this to prevent the Hub container to crash loop.
+  pid=$(cat /jupyterhub-proxy.pid)
+  kill -9 "${pid}"
+  rm /jupyterhub-proxy.pid
+  echo "Just killed ${pid}."
+
   # Checks if runs on AI Notebook by reading a metadata passed as an environment variable.
   jupyterhub_host_type=$( curl ${metadata_base_url}/instance/attributes/jupyterhub-host-type -H "Metadata-Flavor: Google" )
   if [ "$jupyterhub_host_type" == "ain" ]; then

--- a/docker/jupyterhub.sh
+++ b/docker/jupyterhub.sh
@@ -41,6 +41,16 @@ c.JupyterHub.log_level = 'DEBUG'
 EOT
 }
 
+function kill-proxy {
+  proxy_file=$1
+  if test -f "$proxy_file"; then
+    pid=$(cat "${proxy_file}")
+    kill -9 "${pid}"
+    rm "${proxy_file}"
+    echo "Just killed ${pid}."
+  fi
+}
+
 # 'append-to-jupyterhub-config'
 # Checks if JupyterHub is running on an AI Platform Notebook instance
 # and appends the proper configuration to jupyterhub_config.py.
@@ -48,13 +58,7 @@ EOT
 function append-to-jupyterhub-config {
   # Adding this to prevent the Hub container to crash loop.
   # Without the rm, the crash loop still happens.
-  proxy_file=/jupyterhub-proxy.pid
-  if test -f "$proxy_file"; then
-    pid=$(cat ${proxy_file})
-    kill -9 "${pid}"
-    rm ${proxy_file}
-    echo "Just killed ${pid}."
-  fi
+  kill-proxy /jupyterhub-proxy.pid
 
   # Checks if runs on AI Notebook by reading a metadata passed as an environment variable.
   jupyterhub_host_type=$( curl ${metadata_base_url}/instance/attributes/jupyterhub-host-type -H "Metadata-Flavor: Google" )

--- a/docker/jupyterhub.sh
+++ b/docker/jupyterhub.sh
@@ -47,6 +47,7 @@ EOT
 # For tries, GCE or local can use the default jupyterhub_config.py
 function append-to-jupyterhub-config {
   # Adding this to prevent the Hub container to crash loop.
+  # Without the rm, the crash loop still happens.
   pid=$(cat /jupyterhub-proxy.pid)
   kill -9 "${pid}"
   rm /jupyterhub-proxy.pid


### PR DESCRIPTION
Leverage jupyterhub.sh to:
- kill the process `node /usr/local/bin/configurable-http-proxy ...`
- remove the /jupyterhub-proxy.pid file

This seems to fix a behavior in the `_check_previous_process` function in [proxy.py](https://github.com/jupyterhub/jupyterhub/blob/master/jupyterhub/proxy.py#L524) which prevent container to consistently restart without failing.