### PR TITLE
Pin JupyterHub version to 1.2.2 to prevent 500 on first login

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN pip install --upgrade \
     google-auth \
     googleapis-common-protos \
     google-auth-httplib2 \
-    jupyterhub
+    jupyterhub==1.2.2
 
 RUN npm install -g configurable-http-proxy
 


### PR DESCRIPTION
- With v1.3, `render_template` default to asyc which breaks the first login to Dataproc Hub.
- Although we can set a sync=True parameter in the [GCP Proxy Authenticator](https://github.com/GoogleCloudPlatform/jupyterhub-gcp-proxies-authenticator/blob/master/gcpproxiesauthenticator/gcpproxiesauthenticator.py#L114), for now pinning JupyterHub version to 1.2.2 also fix the problem.