### PR TITLE
Add checkbox for personal auth outside custom clusters

### DIFF
--- a/dataprocspawner/customize_cluster.py
+++ b/dataprocspawner/customize_cluster.py
@@ -104,7 +104,7 @@ def get_base_cluster_html_form(configs, locations_list, jhub_region):
         </div>
         <div class="mdc-checkbox__ripple"></div>
       </div>
-      <label for="personal-auth">Make notebook private.</label>
+      <label for="personal-auth">Make the notebook personal.</label>
     </div>
   """
 

--- a/dataprocspawner/customize_cluster.py
+++ b/dataprocspawner/customize_cluster.py
@@ -89,7 +89,26 @@ def get_base_cluster_html_form(configs, locations_list, jhub_region):
     \t</div>
     </section>"""
 
-  return html_config + '\n' + html_zone
+  # Personal notebook configuration
+  html_personal = """
+    <div class="mdc-form-field">
+      <div class="mdc-checkbox">
+        <input type="checkbox" class="mdc-checkbox__native-control" id="personal-auth" name="personal_auth" checked/>
+        <div class="mdc-checkbox__background">
+          <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+            <path class="mdc-checkbox__checkmark-path"
+                  fill="none"
+                  d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+          </svg>
+          <div class="mdc-checkbox__mixedmark"></div>
+        </div>
+        <div class="mdc-checkbox__ripple"></div>
+      </div>
+      <label for="personal-auth">Make notebook private.</label>
+    </div>
+  """
+
+  return html_config + '\n' + html_zone + '\n' + html_personal
 
 
 def get_custom_cluster_html_form(autoscaling_policies, node_types):

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -1361,6 +1361,7 @@ class DataprocSpawner(Spawner):
       # ones if relevant.
       gcs_config_file = self.user_options.get('cluster_type')
       cluster_zone = self.user_options.get('cluster_zone')
+      personal_auth = self.user_options.get('personal_auth')
 
       # Reads the cluster config from yaml
       self.log.info(f'Reading config file at {gcs_config_file}')
@@ -1382,6 +1383,11 @@ class DataprocSpawner(Spawner):
 
       if 'metadata' in cluster_data['config']['gce_cluster_config']:
         metadata = cluster_data['config']['gce_cluster_config']['metadata']
+
+      # User checked the box to limit access to CG URL.
+      if personal_auth == 'on':
+        (cluster_data['config']['software_config']['properties']
+                     [personal_auth_property]) = self.user.name
 
       # Sets default network for the cluster if not already provided in YAML.
       if ('network_uri' not in cluster_data['config']['gce_cluster_config'] and


### PR DESCRIPTION
- Creates a checkbox for user to decide whether their notebook is private or not (ie if they share the Component Gateway URL, can other users with `dataproc.clusters.use` role in the project access the URL)
- Checkbox selected by default to mitigate unwanted possible access (even if the URL is not really guessable)