### PR TITLE
Swap property so force-single-user only applies to CG

### DIFF
--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -1351,7 +1351,7 @@ class DataprocSpawner(Spawner):
     # but must be set in case there is no form.
     cluster_data = cluster_data or {}
     cluster_zone = self.zone
-    personal_auth_property = 'dataproc:dataproc.personal-auth.user'
+    personal_auth_property = 'dataproc:dataproc.exclusive.user'
 
     # Sets the cluster definition with form data.
     if self.user_options:
@@ -1472,7 +1472,7 @@ class DataprocSpawner(Spawner):
       else:
         cluster_data['config']['software_config']['image_version'] = '1.4-debian9'
 
-    # A user can only set 'dataproc:dataproc.personal-auth.user' for themselves.
+    # A user can only set 'dataproc:dataproc.exclusive.user' for themselves.
     # Otherwise the CG Url is not accessible by either identities. So, if set,
     # the personal auth property can only have the value of self.user.name. For
     # that reason, there is no priority between yaml and user.

--- a/tests/test_data/perso.yaml
+++ b/tests/test_data/perso.yaml
@@ -2,4 +2,4 @@ clusterName: 'personal'
 config:
   softwareConfig:
     properties:
-      dataproc:dataproc.personal-auth.user: 'user@example.com'
+      dataproc:dataproc.exclusive.user: 'user@example.com'

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -531,7 +531,7 @@ class TestDataprocSpawner:
     assert config_built['config']['software_config']['properties']['dataproc:jupyter.hub.env'] == 'test-env-str'
     assert config_built['config']['software_config']['properties']['dataproc:jupyter.hub.menu.enabled'] == 'true'
     assert 'dataproc:jupyter.hub.enabled' not in config_built['config']['software_config']['properties']
-    assert 'dataproc:dataproc.personal-auth.user' not in config_built['config']['software_config']['properties']
+    assert 'dataproc:dataproc.exclusive.user' not in config_built['config']['software_config']['properties']
 
   def test_cluster_definition_overrides(self, monkeypatch):
     """Check that config settings incompatible with JupyterHub are overwritten correctly."""
@@ -1206,7 +1206,7 @@ class TestDataprocSpawner:
     spawner.args_str = "test-args-str"
     config_built = spawner._build_cluster_config()
     assert (config_built['config']['software_config']['properties']
-        ['dataproc:dataproc.personal-auth.user']) == spawner.user.name
+        ['dataproc:dataproc.exclusive.user']) == spawner.user.name
 
   def test_unified_auth_yaml(self, monkeypatch):
     fake_creds = AnonymousCredentials()
@@ -1233,7 +1233,7 @@ class TestDataprocSpawner:
     config_built = spawner._build_cluster_config()
 
     assert (config_built['config']['software_config']['properties']
-        ['dataproc:dataproc.personal-auth.user']) == spawner.user.name
+        ['dataproc:dataproc.exclusive.user']) == spawner.user.name
 
   def test_unified_auth_user(self, monkeypatch):
     fake_creds = AnonymousCredentials()
@@ -1257,10 +1257,10 @@ class TestDataprocSpawner:
       'cluster_type': 'perso.yaml',
       'cluster_zone': 'us-central-1',
       "cluster_props_prefix_0": "dataproc",
-      "cluster_props_key_0": "dataproc.personal-auth.user",
+      "cluster_props_key_0": "dataproc.exclusive.user",
       "cluster_props_val_0": "user@example.com"
     }
     config_built = spawner._build_cluster_config()
     assert (config_built['config']['software_config']['properties']
-        ['dataproc:dataproc.personal-auth.user']) == spawner.user.name
+        ['dataproc:dataproc.exclusive.user']) == spawner.user.name
 


### PR DESCRIPTION
Replaces dataproc:dataproc.personal-auth.user with dataproc:dataproc.exclusive.user