### PR TITLE
Update args for compatibility with latest JupyterHub versions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,6 +26,9 @@ jobs:
       # Checkout the code base
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
 
       # Run Linter against code base
       - name: Lint Code Base

--- a/dataprocspawner/spawner.py
+++ b/dataprocspawner/spawner.py
@@ -725,8 +725,8 @@ class DataprocSpawner(Spawner):
 
     if self.debug:
       args.append('--debug')
-    args.append('--NotebookApp.hub_activity_interval=0')
-    args.append('--NotebookApp.hub_host={}'.format(self.hub_host))
+    args.append('--SingleUserNotebookApp.hub_activity_interval=0')
+    args.append('--SingleUserNotebookApp.hub_host={}'.format(self.hub_host))
     args.extend(self.args)
     return args
 

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -608,11 +608,8 @@ class TestDataprocSpawner:
 
     config_built = spawner._build_cluster_config()
 
-    # Verify that we disable Component Gateway (temporarily)
+    # Verify that we enable Component Gateway
     assert config_built['config']['endpoint_config']['enable_http_port_access'] == True
-    # Verify that we disable preemptibility (temporarily)
-    assert 'preemptibility' not in config_built['config']['master_config']
-    assert 'preemptibility' not in config_built['config']['worker_config']
     # Verify that we removed cluster-specific namenode properties
     assert 'hdfs:dfs.namenode.lifeline.rpc-address' not in config_built['config']['software_config']['properties']
     assert 'hdfs:dfs.namenode.servicerpc-address' not in config_built['config']['software_config']['properties']


### PR DESCRIPTION
Explicitly set singleuser args on SingleUserNotebookApp: setting config values on NotebookApp breaks JupyterLab in newer versions.

I tested this change with the latest 1.4, 1.5, and 2.0 images and verified that the JupyterLab UI worked correctly.