### PR TITLE
Place Jupyterhub configuration in a fixed known location

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,7 +67,7 @@ RUN pip install /tmp/dataprocspawner/
 COPY static/templates/ /etc/jupyterhub/templates/
 COPY static/mdc/ /usr/local/share/jupyterhub/static/mdc/
 
-COPY docker/jupyterhub_config.py .
+COPY docker/jupyterhub_config.py /etc/jupyterhub/jupyterhub_config.py
 
 EXPOSE 8080
 

--- a/docker/jupyterhub.sh
+++ b/docker/jupyterhub.sh
@@ -271,4 +271,4 @@ function set-default-name-pattern() {
 append-to-jupyterhub-config
 
 # Starts JupyterHub.
-jupyterhub
+jupyterhub -f /etc/jupyterhub/jupyterhub_config.py


### PR DESCRIPTION
Previously we relied on the config file being in the same working directory
as the Jupyterhub command was invoked from, which is brittle. This
places the config in a known location and explicitly passes the path
when starting Jupyterhub.